### PR TITLE
Add WithClient method

### DIFF
--- a/request.go
+++ b/request.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Request struct {
+	Client  *http.Client
 	Request *http.Request
 	Error   error
 	Data    interface{}
@@ -18,7 +19,7 @@ func (r *Request) Call() error {
 		return r.Error
 	}
 
-	resp, err := http.DefaultClient.Do(r.Request)
+	resp, err := r.Client.Do(r.Request)
 	if err != nil {
 		return err
 	}
@@ -37,6 +38,10 @@ func (r *Request) Call() error {
 	return nil
 }
 
+func (r *Request) WithClient(client *http.Client) {
+	r.Client = client
+}
+
 func (i *Infura) newRequest(input input, output interface{}) (req *Request) {
 	args := map[string]interface{}{
 		"jsonrpc": "2.0",
@@ -53,6 +58,7 @@ func (i *Infura) newRequest(input input, output interface{}) (req *Request) {
 	httpReq, err := http.NewRequest("POST", i.network.URL()+i.projectID, bytes.NewReader(body))
 
 	req = &Request{
+		Client:  http.DefaultClient,
 		Request: httpReq,
 		Error:   err,
 		Data:    output,


### PR DESCRIPTION
In `net/http` package doesn’t specify a timeout for default HTTP client.
https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779

This fix allows you to specify a custom http client:

```golang
package main

import (
	"fmt"
	"time"
	"net/http"
	"github.com/daisuke310vvv/infura-go"
)

func main() {
	config := infura.NewConfig("<API_KEY>", infura.Ropsten)
	infuraClient := infura.New(config)

	input := &infura.EthGetBalanceInput{
	    Address:        "0x5c66b0d82df26e8FE165Be6628F5f5e1f1bccD5C",
	    BlockParameter: infura.NewBlockParameter("latest"),
	}

	client := &http.Client{
		Timeout: time.Second * 10,
	}
	
	req, res := infuraClient.EthGetBalanceRequest(input)
	req.WithClient(client)
	err := req.Call()
	if err != nil {
		fmt.Println(err)
	}

	fmt.Println(res.Result)
}
```